### PR TITLE
Updated requirement files to include psutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ PyQt5
 matplotlib
 opencv-python
 scikit-image
+psutil

--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -3,3 +3,4 @@ PyQt5
 matplotlib
 opencv-python
 scikit-image
+psutil


### PR DESCRIPTION
Simple fix: the requirement files did not include psutil which is needed in both the CUDA and CPU-only code paths.